### PR TITLE
Add counter per host

### DIFF
--- a/tcp_exporter.c
+++ b/tcp_exporter.c
@@ -177,7 +177,7 @@ enum MHD_Result serve_connections_in_prometheus_format(void *cls, struct MHD_Con
                  "conntrack_opening_connections{host=\"%s\"} %d\n"
                  "# HELP conntrack_open_connections How many open connections are there to the remote host?\n"
                  "# TYPE conntrack_open_connections gauge\n"
-                 "conntrack_opening_connections{host=\"%s\"} %d\n"
+                 "conntrack_open_connections{host=\"%s\"} %d\n"
                  "# HELP conntrack_closing_connections How many connections to the remote host are currently closing?\n"
                  "# TYPE conntrack_closing_connections gauge\n"
                  "conntrack_closing_connections{host=\"%s\"} %d\n"

--- a/tcp_exporter.c
+++ b/tcp_exporter.c
@@ -8,6 +8,7 @@
 #include <netinet/tcp.h>
 
 #define PORT 9318
+#define INITIAL_BUFFER_SIZE 1024
 
 // Structure to track connections by host and port
 struct connection_metrics {
@@ -21,6 +22,8 @@ struct connection_metrics {
 
 #define MAX_HOSTS 100
 
+// TODO: This cannot be a global variable
+// due the fact that this have to be recomputed on per request.
 struct connection_metrics metrics[MAX_HOSTS];
 int metrics_count = 0;
 
@@ -78,6 +81,27 @@ const char *map_tcp_state_to_prometheus(int tcp_state) {
     }
 }
 
+int append_to_buffer(char **response, size_t *response_size, const char *new_content) {
+    size_t new_content_len = strlen(new_content);
+    size_t current_len = strlen(*response);
+
+    // Check if buffer needs to be resized
+    if (current_len + new_content_len + 1 > *response_size) {
+        size_t new_size = *response_size * 2 + new_content_len;  // Double the buffer size
+        char *new_buffer = realloc(*response, new_size);
+        if (!new_buffer) {
+            fprintf(stderr, "Failed to allocate memory\n");
+            return 1;  // Memory allocation failed
+        }
+        *response = new_buffer;
+        *response_size = new_size;
+    }
+
+    // Append the new content
+    strcat(*response, new_content);
+    return 0;
+}
+
 /**
  * @brief Serves metrics in Prometheus format over HTTP.
  *
@@ -94,37 +118,43 @@ const char *map_tcp_state_to_prometheus(int tcp_state) {
 enum MHD_Result serve_metrics(void *cls, struct MHD_Connection *connection,
                               const char *url, const char *method, const char *version,
                               const char *upload_data, size_t *upload_data_size, void **con_cls) {
-    char response[4096] = {0};
-    char buffer[512];
+    size_t buffer_size = INITIAL_BUFFER_SIZE;
+    char *response = malloc(buffer_size);
+    if (!response) {
+        perror("failed to allocate memory for response");
+        return MHD_NO;
+    }
+    response[0] = '\0';
 
-    // Prometheus metrics template
-    strcat(response,
-           "# HELP conntrack_opening_connections How many connections to the remote host are currently opening?\n"
-           "# TYPE conntrack_opening_connections gauge\n"
-           "# HELP conntrack_open_connections How many open connections are there to the remote host?\n"
-           "# TYPE conntrack_open_connections gauge\n"
-           "# HELP conntrack_closing_connections How many connections to the remote host are currently closing?\n"
-           "# TYPE conntrack_closing_connections gauge\n"
-           "# HELP conntrack_closed_connections How many connections to the remote host have recently closed?\n"
-           "# TYPE conntrack_closed_connections gauge\n");
-
-    // For each host, add its metrics
+       // For each host, add its metrics
     for (int i = 0; i < metrics_count; i++) {
+        char buffer[1024];
         snprintf(buffer, sizeof(buffer),
-                 "conntrack_opening_connections{host=\"%s:%u\"} %d\n"
+                 "# HELP conntrack_opening_connections How many connections to the remote host are currently opening?\n"
+                 "# TYPE conntrack_opening_connections gauge\n"
                  "conntrack_open_connections{host=\"%s:%u\"} %d\n"
+                 "# HELP conntrack_open_connections How many open connections are there to the remote host?\n"
+                 "# TYPE conntrack_open_connections gauge\n"
+                 "conntrack_opening_connections{host=\"%s:%u\"} %d\n"
+                 "# HELP conntrack_closing_connections How many connections to the remote host are currently closing?\n"
+                 "# TYPE conntrack_closing_connections gauge\n"
                  "conntrack_closing_connections{host=\"%s:%u\"} %d\n"
+                 "# HELP conntrack_closed_connections How many connections to the remote host have recently closed?\n"
+                 "# TYPE conntrack_closed_connections gauge\n"
                  "conntrack_closed_connections{host=\"%s:%u\"} %d\n",
                  metrics[i].host, metrics[i].port, metrics[i].opening_connections,
                  metrics[i].host, metrics[i].port, metrics[i].open_connections,
                  metrics[i].host, metrics[i].port, metrics[i].closing_connections,
                  metrics[i].host, metrics[i].port, metrics[i].closed_connections);
 
-        strcat(response, buffer);
+        if (append_to_buffer(&response, &buffer_size, buffer)) {
+            free(response);
+            return MHD_NO;
+        }
     }
 
     struct MHD_Response *http_response;
-    http_response = MHD_create_response_from_buffer(strlen(response), (void *)response, MHD_RESPMEM_PERSISTENT);
+    http_response = MHD_create_response_from_buffer(strlen(response), (void *)response, MHD_RESPMEM_MUST_FREE);
     enum MHD_Result ret = MHD_queue_response(connection, MHD_HTTP_OK, http_response);
     MHD_destroy_response(http_response);
     return ret;
@@ -137,7 +167,7 @@ enum MHD_Result serve_metrics(void *cls, struct MHD_Connection *connection,
  */
 int start_http_server() {
     struct MHD_Daemon *daemon;
-    daemon = MHD_start_daemon(MHD_USE_SELECT_INTERNALLY, PORT, NULL, NULL, &serve_metrics, NULL, MHD_OPTION_END);
+    daemon = MHD_start_daemon(MHD_USE_INTERNAL_POLLING_THREAD, PORT, NULL, NULL, &serve_metrics, NULL, MHD_OPTION_END);
     if (NULL == daemon) {
         return 1;
     }
@@ -198,7 +228,10 @@ static int event_callback(enum nf_conntrack_msg_type type, struct nf_conntrack *
  * @return EXIT_SUCCESS on success, EXIT_FAILURE on failure.
  */
 int main() {
-    start_http_server();
+    if (start_http_server() == 1) {
+        perror("unable to start http server");
+        return EXIT_FAILURE;
+    }
 
     struct nfct_handle *handle;
     handle = nfct_open(CONNTRACK, NF_NETLINK_CONNTRACK_UPDATE);

--- a/tcp_exporter.c
+++ b/tcp_exporter.c
@@ -2,19 +2,81 @@
 #include <stdlib.h>
 #include <libnetfilter_conntrack/libnetfilter_conntrack.h>
 #include <json-c/json.h>
-#include <arpa/inet.h> 
+#include <arpa/inet.h>
 #include <string.h>
 #include <microhttpd.h>
-#include <stdio.h>
-#include <string.h>
+#include <netinet/tcp.h>
 
 #define PORT 9318
 
-int open_connections = 0;
-int opening_connections = 0;
-int closing_connections = 0;
-int closed_connections = 0;
-int log_json_flag = 0;  // Global flag to indicate whether to log JSON data
+// Structure to track connections by host and port
+struct connection_metrics {
+    char host[INET_ADDRSTRLEN];
+    uint16_t port;
+    int opening_connections;
+    int open_connections;
+    int closing_connections;
+    int closed_connections;
+};
+
+#define MAX_HOSTS 100
+
+struct connection_metrics metrics[MAX_HOSTS];
+int metrics_count = 0;
+
+/**
+ * @brief Find or add a connection metric for a given host and port.
+ *
+ * @param ip_str The IP address as a string.
+ * @param port The port number.
+ * @return A pointer to the corresponding connection_metrics structure.
+ */
+struct connection_metrics *find_or_add_metrics(const char *ip_str, uint16_t port) {
+    for (int i = 0; i < metrics_count; i++) {
+        if (strcmp(metrics[i].host, ip_str) == 0 && metrics[i].port == port) {
+            return &metrics[i];
+        }
+    }
+
+    // If not found, add a new entry
+    if (metrics_count < MAX_HOSTS) {
+        strcpy(metrics[metrics_count].host, ip_str);
+        metrics[metrics_count].port = port;
+        metrics[metrics_count].opening_connections = 0;
+        metrics[metrics_count].open_connections = 0;
+        metrics[metrics_count].closing_connections = 0;
+        metrics[metrics_count].closed_connections = 0;
+        return &metrics[metrics_count++];
+    }
+
+    return NULL;
+}
+
+/**
+ * @brief Maps TCP state to Prometheus state.
+ *
+ * @param tcp_state The TCP state.
+ * @return Corresponding state string.
+ */
+const char *map_tcp_state_to_prometheus(int tcp_state) {
+    switch (tcp_state) {
+        case TCP_SYN_SENT:
+        case TCP_SYN_RECV:
+            return "Opening";
+        case TCP_ESTABLISHED:
+            return "Open";
+        case TCP_FIN_WAIT1:
+        case TCP_CLOSE_WAIT:
+        case TCP_LAST_ACK:
+        case TCP_TIME_WAIT:
+        case TCP_FIN_WAIT2:
+            return "Closing";
+        case TCP_CLOSE:
+            return "Closed";
+        default:
+            return NULL;
+    }
+}
 
 /**
  * @brief Serves metrics in Prometheus format over HTTP.
@@ -32,23 +94,34 @@ int log_json_flag = 0;  // Global flag to indicate whether to log JSON data
 enum MHD_Result serve_metrics(void *cls, struct MHD_Connection *connection,
                               const char *url, const char *method, const char *version,
                               const char *upload_data, size_t *upload_data_size, void **con_cls) {
-    const char *metrics_template =
-        "# HELP conntrack_open_connections Number of open connections\n"
-        "# TYPE conntrack_open_connections gauge\n"
-        "conntrack_open_connections %d\n"
-        "# HELP conntrack_opening_connections Number of opening connections\n"
-        "# TYPE conntrack_opening_connections gauge\n"
-        "conntrack_opening_connections %d\n"
-        "# HELP conntrack_closing_connections Number of closing connections\n"
-        "# TYPE conntrack_closing_connections gauge\n"
-        "conntrack_closing_connections %d\n"
-        "# HELP conntrack_closed_connections Number of closed connections\n"
-        "# TYPE conntrack_closed_connections gauge\n"
-        "conntrack_closed_connections %d\n";
+    char response[4096] = {0};
+    char buffer[512];
 
-    char response[1024];
-    snprintf(response, sizeof(response), metrics_template,
-             open_connections, opening_connections, closing_connections, closed_connections);
+    // Prometheus metrics template
+    strcat(response,
+           "# HELP conntrack_opening_connections How many connections to the remote host are currently opening?\n"
+           "# TYPE conntrack_opening_connections gauge\n"
+           "# HELP conntrack_open_connections How many open connections are there to the remote host?\n"
+           "# TYPE conntrack_open_connections gauge\n"
+           "# HELP conntrack_closing_connections How many connections to the remote host are currently closing?\n"
+           "# TYPE conntrack_closing_connections gauge\n"
+           "# HELP conntrack_closed_connections How many connections to the remote host have recently closed?\n"
+           "# TYPE conntrack_closed_connections gauge\n");
+
+    // For each host, add its metrics
+    for (int i = 0; i < metrics_count; i++) {
+        snprintf(buffer, sizeof(buffer),
+                 "conntrack_opening_connections{host=\"%s:%u\"} %d\n"
+                 "conntrack_open_connections{host=\"%s:%u\"} %d\n"
+                 "conntrack_closing_connections{host=\"%s:%u\"} %d\n"
+                 "conntrack_closed_connections{host=\"%s:%u\"} %d\n",
+                 metrics[i].host, metrics[i].port, metrics[i].opening_connections,
+                 metrics[i].host, metrics[i].port, metrics[i].open_connections,
+                 metrics[i].host, metrics[i].port, metrics[i].closing_connections,
+                 metrics[i].host, metrics[i].port, metrics[i].closed_connections);
+
+        strcat(response, buffer);
+    }
 
     struct MHD_Response *http_response;
     http_response = MHD_create_response_from_buffer(strlen(response), (void *)response, MHD_RESPMEM_PERSISTENT);
@@ -73,55 +146,31 @@ int start_http_server() {
 }
 
 /**
- * @brief Updates connection counters based on the connection state.
- *
- * @param state The state of the connection (Opening, Open, Closing, Closed).
- */
-void update_connection_counters(const char *state) {
-    if (strcmp(state, "Opening") == 0) {
-        opening_connections++;
-    } else if (strcmp(state, "Open") == 0) {
-        open_connections++;
-    } else if (strcmp(state, "Closing") == 0) {
-        closing_connections++;
-    } else if (strcmp(state, "Closed") == 0) {
-        closed_connections++;
-    }
-}
-
-/**
  * @brief Logs connection events and updates counters based on state.
  *
- * @param event_type The type of event (e.g., new, update, close).
  * @param ct The connection track object.
  * @param state The state of the connection (e.g., Opening, Open, Closed).
  */
-void log_connection_event(const char *event_type, struct nf_conntrack *ct, const char *state) {
-    char src_ip[INET_ADDRSTRLEN], dst_ip[INET_ADDRSTRLEN];
-    uint32_t src, dst;
+void log_connection_event(struct nf_conntrack *ct, const char *state) {
+    char src_ip[INET_ADDRSTRLEN];
+    uint32_t src_ip_bin = nfct_get_attr_u32(ct, ATTR_ORIG_IPV4_SRC);
+    uint16_t src_port = nfct_get_attr_u16(ct, ATTR_ORIG_PORT_SRC);
 
-    src = nfct_get_attr_u32(ct, ATTR_ORIG_IPV4_SRC);
-    dst = nfct_get_attr_u32(ct, ATTR_ORIG_IPV4_DST);
+    inet_ntop(AF_INET, &src_ip_bin, src_ip, sizeof(src_ip));
 
-    inet_ntop(AF_INET, &src, src_ip, sizeof(src_ip));
-    inet_ntop(AF_INET, &dst, dst_ip, sizeof(dst_ip));
+    struct connection_metrics *metrics = find_or_add_metrics(src_ip, src_port);
 
-    // Log the connection event in JSON format if the --log-json flag is set
-    if (log_json_flag) {
-        json_object *jobj = json_object_new_object();
-        json_object_object_add(jobj, "event_type", json_object_new_string(event_type));
-        json_object_object_add(jobj, "original_source_host", json_object_new_string(src_ip));
-        json_object_object_add(jobj, "original_destination_host", json_object_new_string(dst_ip));
-        json_object_object_add(jobj, "reply_source_host", json_object_new_string(dst_ip));
-        json_object_object_add(jobj, "reply_destination_host", json_object_new_string(src_ip));
-        json_object_object_add(jobj, "state", json_object_new_string(state));
-
-        printf("%s\n", json_object_to_json_string(jobj));
-
-        json_object_put(jobj); // Free JSON object
+    if (metrics != NULL) {
+        if (strcmp(state, "Opening") == 0) {
+            metrics->opening_connections++;
+        } else if (strcmp(state, "Open") == 0) {
+            metrics->open_connections++;
+        } else if (strcmp(state, "Closing") == 0) {
+            metrics->closing_connections++;
+        } else if (strcmp(state, "Closed") == 0) {
+            metrics->closed_connections++;
+        }
     }
-
-    update_connection_counters(state);
 }
 
 /**
@@ -133,42 +182,24 @@ void log_connection_event(const char *event_type, struct nf_conntrack *ct, const
  * @return NFCT_CB_CONTINUE to continue processing events.
  */
 static int event_callback(enum nf_conntrack_msg_type type, struct nf_conntrack *ct, void *data) {
-    switch (type) {
-        case NFCT_T_NEW:
-            log_connection_event("new", ct, "Opening");
-            break;
-        case NFCT_T_UPDATE:
-            log_connection_event("update", ct, "Open");
-            break;
-        case NFCT_T_DESTROY:
-            log_connection_event("close", ct, "Closed");
-            break;
-        default:
-            break;
+    int tcp_state = nfct_get_attr_u8(ct, ATTR_TCP_STATE);
+    const char *state = map_tcp_state_to_prometheus(tcp_state);
+
+    if (state != NULL) {
+        log_connection_event(ct, state);
     }
+
     return NFCT_CB_CONTINUE;
 }
 
 /**
  * @brief Main function that starts the HTTP server and listens for connection events.
  *
- * @param argc Number of command-line arguments.
- * @param argv Command-line arguments.
  * @return EXIT_SUCCESS on success, EXIT_FAILURE on failure.
  */
-int main(int argc, char *argv[]) {
-    // Check for --log-json flag in command-line arguments
-    for (int i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "--log-json") == 0) {
-            log_json_flag = 1;  // Enable JSON logging if flag is passed
-            break;
-        }
-    }
-
-    // Start the HTTP server to expose metrics
+int main() {
     start_http_server();
 
-    // Initialize conntrack handler
     struct nfct_handle *handle;
     handle = nfct_open(CONNTRACK, NF_NETLINK_CONNTRACK_UPDATE);
     if (!handle) {
@@ -176,10 +207,7 @@ int main(int argc, char *argv[]) {
         return EXIT_FAILURE;
     }
 
-    // Register callback for connection events
     nfct_callback_register(handle, NFCT_T_ALL, event_callback, NULL);
-
-    // Loop to listen for connection events
     nfct_catch(handle);
 
     nfct_close(handle);

--- a/tcp_exporter.c
+++ b/tcp_exporter.c
@@ -184,11 +184,11 @@ int start_http_server() {
 void log_connection_event(struct nf_conntrack *ct, const char *state) {
     char src_ip[INET_ADDRSTRLEN];
     uint32_t src_ip_bin = nfct_get_attr_u32(ct, ATTR_ORIG_IPV4_SRC);
-    uint16_t src_port = nfct_get_attr_u16(ct, ATTR_ORIG_PORT_SRC);
+    uint16_t dst_port = nfct_get_attr_u16(ct, ATTR_ORIG_PORT_DST);
 
     inet_ntop(AF_INET, &src_ip_bin, src_ip, sizeof(src_ip));
 
-    struct connection_metrics *metrics = find_or_add_metrics(src_ip, src_port);
+    struct connection_metrics *metrics = find_or_add_metrics(src_ip, dst_port);
 
     if (metrics != NULL) {
         if (strcmp(state, "Opening") == 0) {


### PR DESCRIPTION
WIP,  need to add the counters and position better the response

```
❯ curl -s localhost:9318/metrics
# HELP conntrack_opening_connections How many connections to the remote host are currently opening?
# TYPE conntrack_opening_connections gauge
# HELP conntrack_open_connections How many open connections are there to the remote host?
# TYPE conntrack_open_connections gauge
# HELP conntrack_closing_connections How many connections to the remote host are currently closing?
# TYPE conntrack_closing_connections gauge
# HELP conntrack_closed_connections How many connections to the remote host have recently closed?
# TYPE conntrack_closed_connections gauge
conntrack_opening_connections{host="127.0.0.1:13539"} 2
conntrack_open_connections{host="127.0.0.1:13539"} 0
conntrack_closing_connections{host="127.0.0.1:13539"} 2
conntrack_closed_connections{host="127.0.0.1:13539"} 1
conntrack_opening_connections{host="10.42.0.9:10889"} 2
conntrack_open_connections{host="10.42.0.9:10889"} 0
conntrack_closing_connections{host="10.42.0.9:10889"} 0
conntrack_closed_connections{host="10.42.0.9:10889"} 0
conntrack_opening_connections{host="10.42.0.9:29924"} 2
conntrack_open_connections{host="10.42.0.9:29924"} 0
conntrack_closing_connections{host="10.42.0.9:29924"} 0
conntrack_closed_connections{host="10.42.0.9:29924"} 0
conntrack_opening_connections{host="10.42.0.9:31972"} 2
```